### PR TITLE
翻訳修正(zh_tw,zh_cn)

### DIFF
--- a/properties/appResource_zh_cn.properties
+++ b/properties/appResource_zh_cn.properties
@@ -180,7 +180,7 @@ part_change.copy=复制
 score_property=乐谱属性
 score_property.name=<乐谱名称>
 score_property.author=<乐谱作者>
-score_property.measure=<时间>
+score_property.measure=<拍子>
 
 ####### mmltrackview.* #######
 instrument.nouse_chorus=没有合唱声部

--- a/properties/appResource_zh_cn.properties
+++ b/properties/appResource_zh_cn.properties
@@ -180,7 +180,7 @@ part_change.copy=复制
 score_property=乐谱属性
 score_property.name=<乐谱名称>
 score_property.author=<乐谱作者>
-score_property.measure=<拍子>
+score_property.measure=<拍号>
 
 ####### mmltrackview.* #######
 instrument.nouse_chorus=没有合唱声部

--- a/properties/appResource_zh_tw.properties
+++ b/properties/appResource_zh_tw.properties
@@ -180,7 +180,7 @@ part_change.copy=複製
 score_property=樂譜屬性
 score_property.name=<樂譜名稱>
 score_property.author=<樂譜作者>
-score_property.measure=<拍子>
+score_property.measure=<拍號>
 
 ####### mmltrackview.* #######
 instrument.nouse_chorus=沒有合唱聲部

--- a/properties/appResource_zh_tw.properties
+++ b/properties/appResource_zh_tw.properties
@@ -180,7 +180,7 @@ part_change.copy=複製
 score_property=樂譜屬性
 score_property.name=<樂譜名稱>
 score_property.author=<樂譜作者>
-score_property.measure=<時間>
+score_property.measure=<拍子>
 
 ####### mmltrackview.* #######
 instrument.nouse_chorus=沒有合唱聲部


### PR DESCRIPTION
zh_cnとzh_twのフォント表示が異常になります。
zh↓
![zh](https://user-images.githubusercontent.com/48663014/144370542-d9af062e-b909-4b5a-8343-8cb31e404629.png)
ja↓
![ja](https://user-images.githubusercontent.com/48663014/144370556-7fbc1bc7-9792-46bd-86d5-95ea99134f6d.png)